### PR TITLE
Stop tracking ./dist files, and create the directory on first install.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 .lock-wscript
 
 docs
+
+# Build files
+dist/

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "author": "Algolia unicorn factory <hey@algolia.com>",
   "scripts": {
+    "postinstall": "mkdir -p ./dist",
     "build:js": "NODE_ENV=production browserify -d src/index.js | uglifyjs -c warnings=false -m > dist/algoliasearch-ui-kit.min.js && gzip -k -f -9 dist/algoliasearch-ui-kit.min.js",
     "watch:js": "watchify -v -d src/index.js -o dist/algoliasearch-ui-kit.js",
     "serve": "static -z -a 0.0.0.0 ."


### PR DESCRIPTION
We should not commit any files in the `./dist` folder, so it's safer to just ignore the whole dir.

Also, the `npm run watch:js` and `npm run build:js` tasks were failing because of a non-existent `./dist` folder.
